### PR TITLE
Fix reg d included definitions

### DIFF
--- a/regconfig/reg_d.py
+++ b/regconfig/reg_d.py
@@ -1,18 +1,18 @@
 #### Regulation D
 
 INCLUDE_DEFINITIONS_IN_PART_1004 = [
-     ('Creditor', 'Creditor shall have the same meaning as in 12 CFR 226.2'),
+    ('Creditor', 'Creditor shall have the same meaning as in 12 CFR 226.2'),
 ]
 
 PARAGRAPH_HIERARCHY_1004 = {
-     '1004.2': [
-         1,
-         1,
-         2, 2, 2,
-         1,
-         1,
-         2, 2, 2, 2,
-         1,
-         1,
-     ],
+    '1004.2': [
+        1,
+        1,
+        2, 2, 2,
+        1,
+        1,
+        2, 2, 2, 2,
+        1,
+        1,
+    ],
 }

--- a/regconfig/reg_d.py
+++ b/regconfig/reg_d.py
@@ -1,21 +1,18 @@
 #### Regulation D
 
 INCLUDE_DEFINITIONS_IN_PART_1004 = [
-    ('Alternative mortgage transaction', 'Alternative mortgage transaction'),
-    ('Creditor', 'Creditor'),
-    ('State', 'State'),
-    ('State law', 'State law'),
+     ('Creditor', 'Creditor shall have the same meaning as in 12 CFR 226.2'),
 ]
 
 PARAGRAPH_HIERARCHY_1004 = {
-    '1004.2': [
-        1,
-        1,
-        2, 2, 2,
-        1,
-        1,
-        2, 2, 2, 2,
-        1,
-        1,
-    ],
+     '1004.2': [
+         1,
+         1,
+         2, 2, 2,
+         1,
+         1,
+         2, 2, 2, 2,
+         1,
+         1,
+     ],
 }


### PR DESCRIPTION
This is a simple change to the `INCLUDE_DEFINITIONS_IN` configuration for Reg D to remove all but "Creditor" and add some context for "Creditor". All the definitions that were removed seem to work regardless.
